### PR TITLE
Allow a 'missing' default driver

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,44 @@
+{
+  "env": {
+    "node": true,
+    "es6": true
+  },
+  "parserOptions": {
+    "ecmaVersion": 9
+  },
+  "extends": "eslint:recommended",
+  "rules": {
+    "linebreak-style": [
+      "error",
+      "unix"
+    ],
+    "quotes": [
+      "error",
+      "single",
+      {
+        "allowTemplateLiterals": true
+      }
+    ],
+    "semi": [
+      "error",
+      "always"
+    ],
+    "strict": [
+      "error",
+      "safe"
+    ]
+  },
+  "overrides": [
+    {
+      "files": [
+        "test/**/*.js"
+      ],
+      "env": {
+        "mocha": true
+      },
+      "rules": {
+        "no-console": "off"
+      }
+    }
+  ]
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -104,8 +104,11 @@ class DriverManager extends EventEmitter {
     }
 
     /**
-     * Returns a driver by its id. If no driver is found and allowNull is falsey, a boom.badRequest exception is thrown.
-     * if an id argument is supplied but undefined, the function shortcircuits and returns undefined.
+     * Returns a driver by its id.
+     * If no driver is found
+     *  - and a 'missing' driver has been configured -- return the missing driver
+     *  - otherwise if allowNull is falsey -- a boom.badRequest exception is thrown.
+     *  - otherwise fall through and ultimately return undefined
      * @param id
      * @param allowNull
      * @return {*}
@@ -113,9 +116,6 @@ class DriverManager extends EventEmitter {
     get (id, allowNull) {
         if (arguments.length === 0) {
             return _.clone(this.drivers);
-        } else if (id === undefined) {
-            // cannot get driver with id "undefined". All drivers must have an id
-            return undefined;
         }
 
         if (!this.exists(id)) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -18,16 +18,21 @@ class DriverManager extends EventEmitter {
         this.schema = joiSchema;
         this.options = options;
         this.driverType = driverType;
-        // validate (but do not add) a 'missing' driver if provided
-        this.missing = missing;
+        // validate (but do not add) a 'missing' driver generator if provided
+        if (missing) {
+            this.missing = missing;
+        }
     }
 
     set missing (missingDriver) {
-        this._missing = missingDriver && this.validate(_.set(missingDriver, ['id'], '$$missing'));
+        if (!_.isFunction(missingDriver)) throw new Error(`Configured 'missing' driver must be a function`);
+        if (this.exists('missing')) throw new Error(`Cannot configure a default 'missing' driver when a driver with that id has already been added`);
+
+        this._genMissing = (requestedDriverId = '') => this.validate(_.set(missingDriver(requestedDriverId), ['id'], 'missing'));
     }
 
     get missing () {
-        return this._missing;
+        return this._genMissing;
     }
 
     /**
@@ -69,7 +74,9 @@ class DriverManager extends EventEmitter {
     add (driver) {
         driver = this.validate(driver);
 
+        if (this.missing && driver.id === 'missing') throw new Error(`A driver with id 'missing' cannot be registered when the DriverManager already has a default 'missing' driver. This should be done when the DriverManager is created.`);
         if (this.exists(driver.id)) throw new Error(`A driver is already registered with id ${driver.id}`);
+
         this.drivers[driver.id] = driver;
 
         this.emit('add', driver);
@@ -97,7 +104,8 @@ class DriverManager extends EventEmitter {
     }
 
     /**
-     * Returns a driver by its id. If no driver is found and allowNull is falsey, a boom.badRequest exception is thrown
+     * Returns a driver by its id. If no driver is found and allowNull is falsey, a boom.badRequest exception is thrown.
+     * if an id argument is supplied but undefined, the function shortcircuits and returns undefined.
      * @param id
      * @param allowNull
      * @return {*}
@@ -105,11 +113,14 @@ class DriverManager extends EventEmitter {
     get (id, allowNull) {
         if (arguments.length === 0) {
             return _.clone(this.drivers);
+        } else if (id === undefined) {
+            // cannot get driver with id "undefined". All drivers must have an id
+            return undefined;
         }
 
         if (!this.exists(id)) {
-            if (this.missing) return this.missing;
-            if (!allowNull) throw boom.badRequest(`No ${this.driverType} driver registered with id "${id}"`);
+            if (_.isFunction(this.missing)) return this.missing(id);
+            if (!allowNull) throw boom.badRequest(`No ${this.driverType} driver registered with id "${id}" and no default 'missing' driver was configured.`);
         }
 
         return this.drivers[id];
@@ -136,6 +147,8 @@ class DriverManager extends EventEmitter {
      * @param id
      */
     remove (id) {
+        if (id === 'missing') throw new Error(`Cannot remove the configured default 'missing' driver`);
+
         if (this.exists(id)) {
             this.emit('remove', this.drivers[id]);
             delete this.drivers[id];

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,14 +5,67 @@ const EventEmitter = require('events');
 const _ = require('lodash');
 const boom = require('boom');
 
+_.mixin({
+    isAsyncFunction: function (value) {
+        return _.isObject(value) && value[Symbol.toStringTag] === 'AsyncFunction';
+    },
+    isGeneratorFunction: function (value) {
+        return _.isObject(value) && value[Symbol.toStringTag] === 'GeneratorFunction';
+    },
+    isFunctionLike: function (value) {
+        return _.isObject(value) && typeof value === 'function';
+    },
+    noopAsync: async function () {
+
+    }
+});
+
+const notImplemented = exports.notImplemented = _.curry((driverId, fnName) => boom.notImplemented(`Cannot call ${fnName}() - driver '${driverId}' is missing`));
+const makeAsync = exports.makeAsync = makeError => val => async () => {
+    throw makeError(val);
+};
+const makeSync = exports.makeSync = makeError => val => () => {
+    throw makeError(val);
+};
+
 class DriverManager extends EventEmitter {
+    /**
+     * Create a DriverManager
+     *
+     * Supported instance creations:
+     *      new DriverManager(string)
+     *      new DriverManager(string, joiSchema)
+     *      new DriverManager(string, joiSchema, {joiOptions})
+     *      new DriverManager(string, joiSchema, missingFn|true)
+     *      new DriverManager(string, joiSchema, {joiOptions}, missingFn|true)
+     *
+     * @constructor
+     * @param {string} driverType
+     * @param {object=} joiSchema
+     * @param {object=} options
+     * @param {(function|boolean)=} missing
+     */
     constructor (driverType, joiSchema, options, missing) {
         super();
+
+        // 3-arg (type, schema, missingFn|bool) - no options
+        if (arguments.length === 3 && !_.isPlainObject(options)) {
+            missing = options;
+            options = undefined;
+        }
 
         joiSchema = joi.compile(joiSchema || {});
         if (!(joiSchema.describe().children.hasOwnProperty('id'))) {
             joiSchema = joiSchema.concat(joi.object().keys({ id: joi.string().required() }));
         }
+        // generate overlay template for funcs that are defaulted or required based on joiSchema
+        this.fnOverlayTpl = _.reduce(_.get(joiSchema, ['_inner', 'children']), (acc, child) => {
+            const { _type, _flags, _tags } = child.schema;
+            if (!(_type === 'object' && _flags.func && (_flags.default || _flags.presence === 'required'))) return acc;
+
+            const makeError = notImplemented(_, child.key);
+            return _.set(acc, [child.key], (_.isAsyncFunction(_flags.default) || _.contains(_tags, 'async')) ? makeAsync(makeError) : makeSync(makeError));
+        }, {});
 
         this.drivers = {};
         this.schema = joiSchema;
@@ -25,10 +78,19 @@ class DriverManager extends EventEmitter {
     }
 
     set missing (missingDriver) {
-        if (!_.isFunction(missingDriver)) throw new Error(`Configured 'missing' driver must be a function`);
+        if (!_.isFunction(missingDriver) && missingDriver !== true) throw new Error(`Configured 'missing' driver must be a function or 'true'`);
         if (this.exists('missing')) throw new Error(`Cannot configure a default 'missing' driver when a driver with that id has already been added`);
 
-        this._genMissing = (requestedDriverId = '') => this.validate(_.set(missingDriver(requestedDriverId), ['id'], 'missing'));
+        if (missingDriver === true) {
+            missingDriver = _.constant({});
+        }
+
+        // generate base 'missing' driver, overlay any unimplemented known joi-defaulted functions, validate & return
+        this._genMissing = (requestedDriverId = '') => {
+            const missingBase = _.set(missingDriver(requestedDriverId, notImplemented(requestedDriverId)) || {}, ['id'], 'missing');
+            const missing = _.defaults(missingBase, _.mapValues(this.fnOverlayTpl, makeFn => makeFn(requestedDriverId)));
+            return this.validate(missing);
+        };
     }
 
     get missing () {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,140 +1,162 @@
 'use strict';
 
-var joi = require('joi');
-var util = require('util');
-var events = require('events');
-var _ = require('lodash');
-var boom = require('boom');
+const joi = require('joi');
+const EventEmitter = require('events');
+const _ = require('lodash');
+const boom = require('boom');
 
-function DriverManager(driverType, joiSchema, options) {
-    events.EventEmitter.call(this);
-    joiSchema = joi.compile(joiSchema || {});
-    if (!(joiSchema.describe().children.hasOwnProperty('id'))) {
-        joiSchema = joiSchema.concat(joi.object().keys({ id: joi.string().required() }));
+class DriverManager extends EventEmitter {
+    constructor (driverType, joiSchema, options, missing) {
+        super();
+
+        joiSchema = joi.compile(joiSchema || {});
+        if (!(joiSchema.describe().children.hasOwnProperty('id'))) {
+            joiSchema = joiSchema.concat(joi.object().keys({ id: joi.string().required() }));
+        }
+
+        this.drivers = {};
+        this.schema = joiSchema;
+        this.options = options;
+        this.driverType = driverType;
+        // validate (but do not add) a 'missing' driver if provided
+        this.missing = missing;
     }
 
-    this.drivers = {};
-    this.schema = joiSchema;
-    this.options = options;
-    this.driverType = driverType;
+    set missing (missingDriver) {
+        this._missing = missingDriver && this.validate(_.set(missingDriver, ['id'], '$$missing'));
+    }
+
+    get missing () {
+        return this._missing;
+    }
+
+    /**
+     * Called before validation
+     * @param driver
+     * @return {*}
+     */
+    // eslint-disable-next-line no-unused-vars
+    beforeValidate (driver) {
+    }
+
+    /**
+     * Called after successful validation
+     * @param driver
+     */
+    // eslint-disable-next-line no-unused-vars
+    afterValidate (driver) {
+    }
+
+    /**
+     * Validates a driver in a before/after sandwich and returns the validated driver
+     * @param driver
+     * @returns {*}
+     */
+    validate (driver) {
+        joi.validate(this.beforeValidate(driver) || driver, this.schema, this.options, (err, validated) => {
+            if (err) throw err;
+            driver = validated;
+        });
+        this.afterValidate(driver);
+        return driver;
+    }
+
+    /**
+     * Validates and adds a new driver to the driver collection
+     * @param {Object} driver
+     * @return {*}
+     */
+    add (driver) {
+        driver = this.validate(driver);
+
+        if (this.exists(driver.id)) throw new Error(`A driver is already registered with id ${driver.id}`);
+        this.drivers[driver.id] = driver;
+
+        this.emit('add', driver);
+        return driver;
+    }
+
+    /**
+     * Adds all drivers
+     * @param drivers
+     * @return {Array|*} a corresponding array of validated drivers
+     */
+    addAll (drivers) {
+        drivers = _.isArray(drivers) ? drivers : [].slice.call(arguments);
+
+        return drivers.map(d => this.add(d));
+    }
+
+    /**
+     * Tests whether a driver with the supplied id exists
+     * @param driverId
+     * @return {boolean}
+     */
+    exists (driverId) {
+        return this.drivers.hasOwnProperty(driverId);
+    }
+
+    /**
+     * Returns a driver by its id. If no driver is found and allowNull is falsey, a boom.badRequest exception is thrown
+     * @param id
+     * @param allowNull
+     * @return {*}
+     */
+    get (id, allowNull) {
+        if (arguments.length === 0) {
+            return _.clone(this.drivers);
+        }
+
+        if (!this.exists(id)) {
+            if (this.missing) return this.missing;
+            if (!allowNull) throw boom.badRequest(`No ${this.driverType} driver registered with id "${id}"`);
+        }
+
+        return this.drivers[id];
+    }
+
+    /**
+     * Returns an array of registered driver ids
+     * @return {Array}
+     */
+    keys () {
+        return Object.keys(this.drivers);
+    }
+
+    /**
+     * Returns an array of all registered drivers
+     * @return {Array}
+     */
+    all () {
+        return _.values(this.drivers);
+    }
+
+    /**
+     * Removes a driver with the specified id, if present
+     * @param id
+     */
+    remove (id) {
+        if (this.exists(id)) {
+            this.emit('remove', this.drivers[id]);
+            delete this.drivers[id];
+        }
+    }
+
+    /**
+     * Removes all drivers
+     */
+    removeAll () {
+        this.drivers = {};
+        this.emit('removeAll');
+    }
 }
-
-util.inherits(DriverManager, events.EventEmitter);
-
-/**
- * Called before validation
- * @param driver
- * @return {*}
- */
-DriverManager.prototype.beforeValidate = function beforeValidate(driver) {
-};
-
-/**
- * Called after successful validation
- * @param driver
- */
-DriverManager.prototype.afterValidate = function afterValidate(driver) {
-};
-
-/**
- * Validates and adds a new driver to the driver collection
- * @param {Object} driver
- * @return {*}
- */
-DriverManager.prototype.add = function (driver) {
-    var self = this;
-
-    joi.validate(this.beforeValidate(driver) || driver, this.schema, this.options, function (err, validated) {
-        if (err) throw err;
-
-        driver = validated;
-
-        if (self.drivers.hasOwnProperty(driver.id)) throw new Error('A driver is already registered with id ' + driver.id);
-
-        self.drivers[driver.id] = driver;
-    });
-    this.afterValidate(driver);
-    this.emit('add', driver);
-    return driver;
-};
-
-/**
- * Adds all drivers
- * @param drivers
- * @return {Array|*} a corresponding array of validated drivers
- */
-DriverManager.prototype.addAll = function(drivers) {
-    drivers = _.isArray(drivers) ? drivers : [].slice.call(arguments);
-
-    return drivers.map(d => this.add(d));
-};
-
-/**
- * Tests whether a driver with the supplied id exists
- * @param driverId
- * @return {boolean}
- */
-DriverManager.prototype.exists = function (driverId) {
-    return this.drivers.hasOwnProperty(driverId);
-};
-
-/**
- * Returns a driver by its id. If no driver is found and allowNull is falsey, a boom.badRequest exception is thrown
- * @param id
- * @param allowNull
- * @return {*}
- */
-DriverManager.prototype.get = function (id, allowNull) {
-    if (arguments.length === 0) {
-        return _.clone(this.drivers);
-    }
-
-    if (!allowNull && !this.drivers.hasOwnProperty(id)) throw boom.badRequest(util.format('No %s driver registered with id "%s"', this.driverType, id));
-
-    return this.drivers[id];
-};
-
-/**
- * Returns an array of registered driver ids
- * @return {Array}
- */
-DriverManager.prototype.keys = function () {
-    return Object.keys(this.drivers);
-};
-
-/**
- * Returns an array of all registered drivers
- * @return {Array}
- */
-DriverManager.prototype.all = function () {
-    return _.values(this.drivers);
-};
-
-/**
- * Removes a driver with the specified id, if present
- * @param id
- */
-DriverManager.prototype.remove = function (id) {
-    if (this.drivers.hasOwnProperty(id)) {
-        this.emit('remove', this.drivers[id]);
-        delete this.drivers[id];
-    }
-};
-
-/**
- * Removes all drivers
- */
-DriverManager.prototype.removeAll = function () {
-    this.drivers = {};
-    this.emit('removeAll');
-};
 
 exports.DriverManager = DriverManager;
 
-exports.register = function(server, app, next) {
+exports.register = function (server, app, next) {
     const drivers = new Map();
 
-    function driverManager(id, manager) {
+    function driverManager (id, manager) {
         if (manager) {
             drivers.set(id, manager);
             return this;

--- a/lib/index.js
+++ b/lib/index.js
@@ -170,6 +170,7 @@ exports.register = function (server, app, next) {
     const drivers = new Map();
 
     function driverManager (id, manager) {
+        if (!arguments.length) return drivers;
         if (manager) {
             drivers.set(id, manager);
             return this;

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
+    "bluebird": "~2.11.0",
     "chai": "^3.5.0",
+    "chai-as-promised": "^7.1.1",
     "eslint": "^5.16.0",
     "gulp": "^3.8.11",
     "gulp-bump": "^3.1.1",
@@ -27,7 +29,9 @@
     "gulp-load-plugins": "^2.0.0",
     "gulp-mocha": "^6.0.0",
     "gulp-tag-version": "^1.2.1",
-    "mocha": "^5.2.0"
+    "mocha": "^5.2.0",
+    "sinon": "^7.5.0",
+    "sinon-chai": "^3.3.0"
   },
   "dependencies": {
     "boom": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -16,21 +16,22 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
-    "chai": "^2.1.1",
+    "chai": "^3.5.0",
+    "eslint": "^5.16.0",
     "gulp": "^3.8.11",
-    "gulp-bump": "^0.2.2",
+    "gulp-bump": "^3.1.1",
+    "gulp-eslint": "^5.0.0",
     "gulp-filter": "^2.0.2",
-    "gulp-git": "^1.1.0",
-    "gulp-istanbul": "^0.6.0",
-    "gulp-jshint": "^1.9.2",
-    "gulp-mocha": "^2.0.0",
+    "gulp-git": "^2.7.0",
+    "gulp-istanbul": "^1.1.1",
+    "gulp-load-plugins": "^2.0.0",
+    "gulp-mocha": "^6.0.0",
     "gulp-tag-version": "^1.2.1",
-    "jshint-stylish": "^1.0.1",
-    "mocha": "^2.2.1"
+    "mocha": "^5.2.0"
   },
   "dependencies": {
-    "boom": "^2.6.1",
-    "joi": "^9.0.4",
-    "lodash": "^3.5.0"
+    "boom": "4.2.0",
+    "joi": "~9.2.0",
+    "lodash": "~3.10.1"
   }
 }

--- a/test/module-spec.js
+++ b/test/module-spec.js
@@ -1,21 +1,24 @@
 'use strict';
 
-const should = require('chai').should();
+const chai = require('chai');
+chai.use(require('chai-as-promised'));
+const should = chai.should();
 const joi = require('joi');
+const P = require('bluebird');
+const _ = require('lodash');
 const DriverManager = require('../').DriverManager;
 
 describe('DriverManager', function () {
-    const schema = {
-        id: joi.string().required(),
-        name: joi.string().required(),
-        getName: joi.func().default(function () {
-            return this.name;
-        })
-    };
-
-    let drivers;
+    let drivers, schema;
 
     beforeEach(function () {
+        schema = schema = {
+            id: joi.string().required(),
+            name: joi.string().required(),
+            getName: joi.func().default(function () {
+                return this.name;
+            })
+        };
         drivers = new DriverManager('driver', schema);
     });
 
@@ -50,31 +53,53 @@ describe('DriverManager', function () {
     });
 
     describe(`missing driver`, () => {
+        let defaultSyncFn, defaultAsyncFn;
+
+        beforeEach(() => {
+            defaultSyncFn = () => 'sync';
+            defaultAsyncFn = async () => 'async';
+
+            schema = {
+                id: joi.string().required(),
+                name: joi.string().required(),
+                syncFn: joi.func().default(defaultSyncFn),
+                asyncFn: joi.func().default(defaultAsyncFn),
+                requiredSyncFn: joi.func().required(),
+                requiredAsyncFn: joi.func().required().tags('async'),
+                optionalSyncFn: joi.func(),
+                optionalAsyncFn: joi.func().tags('async'),
+                taggedAsyncFn: joi.func().default(defaultSyncFn).tags('async')
+            };
+
+            drivers = new DriverManager('things', schema);
+        });
+
         it(`should return the configured 'missing' driver instead of throwing when getting an unknown driver, if one was provided to the driver manager`, () => {
-            const drivers = new DriverManager('things', schema, null, () => ({ name: 'Missing Driver' }));
+            drivers.missing = () => ({ name: 'Missing Driver' });
             drivers.get.bind(drivers, 'foo').should.not.throw;
             const found = drivers.get('foo');
             should.exist(found);
             found.should.be.an('Object');
             found.should.have.property('id', 'missing');
-            found.should.deep.equal(drivers.missing('foo'));
+            found.should.have.property('name', 'Missing Driver');
+            found.should.have.property('syncFn').that.is.a('function');
+            found.should.have.property('asyncFn');
+            found.asyncFn[Symbol.toStringTag].should.equal('AsyncFunction');
         });
 
         it(`should dynamically generate a missing driver based on the requested driver id`, () => {
-            const drivers = new DriverManager('things', schema, null, id => ({ name: `Missing Driver: ${id}` }));
+            drivers.missing = id => ({ name: `Missing Driver: ${id}` });
             drivers.get.bind(drivers, 'foo').should.not.throw;
             const foundFoo = drivers.get('foo');
             should.exist(foundFoo);
             foundFoo.should.be.an('Object');
             foundFoo.should.have.property('id', 'missing');
             foundFoo.should.have.property('name', 'Missing Driver: foo');
-            foundFoo.should.deep.equal(drivers.missing('foo'));
             const foundBar = drivers.get('bar');
             should.exist(foundBar);
             foundBar.should.be.an('Object');
             foundBar.should.have.property('id', 'missing');
             foundBar.should.have.property('name', 'Missing Driver: bar');
-            foundBar.should.deep.equal(drivers.missing('bar'));
         });
 
         it(`should force the id of the missing driver to be 'missing'`, () => {
@@ -95,7 +120,155 @@ describe('DriverManager', function () {
             should.exist(found);
             found.should.be.an('Object');
             found.should.have.property('id', 'missing');
-            found.should.deep.equal(drivers.missing());
+        });
+
+        it(`should allow configuring a missing driver to the boolean value 'true' for convenience, provided the schema is simple enough`, () => {
+            drivers = new DriverManager('things', {
+                foo: joi.string(),
+                bar: joi.number(),
+                baz: joi.func(),
+                defaulted: joi.func().default(() => ({}))
+            });
+            drivers.missing = true;
+            const found = drivers.get('foo');
+            should.exist(found);
+            found.should.have.property('id', 'missing');
+            found.should.have.property('defaulted').that.is.a('function');
+        });
+
+        it(`should support a 3-arg DriverManager constructor (name, joi, missingFn) to allow specifying a missing impl when there are no opts`, () => {
+            drivers = new DriverManager('things', {
+                name: joi.string().required(),
+                foo: joi.string(),
+                bar: joi.number(),
+                baz: joi.func(),
+                defaulted: joi.func().default(() => ({}))
+            }, reqId => ({ name: `Missing Driver: ${reqId}` }));
+            const found = drivers.get('foo');
+            found.should.have.property('name', `Missing Driver: foo`);
+        });
+
+        it(`should support a 3-arg DriverManager constructor (name, joi, boolean) to allow specifying a missing impl when there are no opts`, () => {
+            drivers = new DriverManager('things', {
+                foo: joi.string(),
+                bar: joi.number(),
+                baz: joi.func(),
+                defaulted: joi.func().default(() => ({}))
+            }, true);
+            const found = drivers.get('foo');
+            found.should.have.property('defaulted').that.is.a('function');
+        });
+
+        it(`should generate an error-throwing synchronous function for joi.func() when there is a default`, () => {
+            drivers.missing = id => ({ name: `Missing Driver: ${id}` });
+            const missing = drivers.get('foo');
+            missing.should.have.property('syncFn').that.is.a('function');
+            missing.syncFn.should.throw(`Cannot call syncFn() - driver 'foo' is missing`);
+        });
+
+        it(`should generate an error-throwing synchronous function for joi.func() when the function is required but not marked async`, () => {
+            drivers.missing = id => ({ name: `Missing Driver: ${id}` });
+            const missing = drivers.get('foo');
+            missing.should.have.property('requiredSyncFn').that.is.a('function');
+            missing.requiredSyncFn.should.throw(`Cannot call requiredSyncFn() - driver 'foo' is missing`);
+        });
+
+        it(`should not generate an error-throwing function for joi.func() when it is not required and there is no default`, () => {
+            drivers.missing = id => ({ name: `Missing Driver: ${id}` });
+            const missing = drivers.get('foo');
+            missing.should.not.have.property('optionalSyncFn');
+            missing.should.not.have.property('optionalAsyncFn');
+        });
+
+        it(`should generate an rejecting async function for the missing driver if the default value is an async function`, async () => {
+            drivers.missing = id => ({ name: `Missing Driver: ${id}` });
+            const missing = drivers.get('foo');
+            missing.should.have.property('asyncFn');
+            missing.asyncFn[Symbol.toStringTag].should.equal('AsyncFunction');
+            // throws in try/catch
+            let e;
+            try {
+                await missing.asyncFn();
+            } catch (err) {
+                e = err;
+            }
+            should.exist(e);
+            e.should.be.an('error').that.has.property('message', `Cannot call asyncFn() - driver 'foo' is missing`);
+            // rejects direct await
+            await (missing.asyncFn().should.eventually.be.rejectedWith(`Cannot call asyncFn() - driver 'foo' is missing`));
+            // rejects in awaited promise
+            await (P.resolve().then(() => missing.asyncFn()).should.eventually.be.rejectedWith(`Cannot call asyncFn() - driver 'foo' is missing`));
+            // rejects in returned promise
+            return P.resolve().then(() => missing.asyncFn()).should.eventually.be.rejectedWith(`Cannot call asyncFn() - driver 'foo' is missing`);
+        });
+
+        it(`should generate an rejecting async function for the missing driver if the property is tagged 'async' even if the default value is a synchronous function`, async () => {
+            drivers.missing = id => ({ name: `Missing Driver: ${id}` });
+            const missing = drivers.get('foo');
+            missing.should.have.property('taggedAsyncFn');
+            missing.taggedAsyncFn[Symbol.toStringTag].should.equal('AsyncFunction');
+            // throws in try/catch
+            let e;
+            try {
+                await missing.taggedAsyncFn();
+            } catch (err) {
+                e = err;
+            }
+            should.exist(e);
+            e.should.be.an('error').that.has.property('message', `Cannot call taggedAsyncFn() - driver 'foo' is missing`);
+            // rejects direct await
+            await (missing.taggedAsyncFn().should.eventually.be.rejectedWith(`Cannot call taggedAsyncFn() - driver 'foo' is missing`));
+            // rejects in awaited promise
+            await (P.resolve().then(() => missing.taggedAsyncFn()).should.eventually.be.rejectedWith(`Cannot call taggedAsyncFn() - driver 'foo' is missing`));
+            // rejects in returned promise
+            return P.resolve().then(() => missing.taggedAsyncFn()).should.eventually.be.rejectedWith(`Cannot call taggedAsyncFn() - driver 'foo' is missing`);
+        });
+
+        it(`should generate an rejecting async function for the missing driver if the function is required`, async () => {
+            drivers.missing = id => ({ name: `Missing Driver: ${id}` });
+            const missing = drivers.get('foo');
+            missing.should.have.property('requiredAsyncFn');
+            missing.requiredAsyncFn[Symbol.toStringTag].should.equal('AsyncFunction');
+            // throws in try/catch
+            let e;
+            try {
+                await missing.requiredAsyncFn();
+            } catch (err) {
+                e = err;
+            }
+            should.exist(e);
+            e.should.be.an('error').that.has.property('message', `Cannot call requiredAsyncFn() - driver 'foo' is missing`);
+            // rejects direct await
+            await (missing.requiredAsyncFn().should.eventually.be.rejectedWith(`Cannot call requiredAsyncFn() - driver 'foo' is missing`));
+            // rejects in awaited promise
+            await (P.resolve().then(() => missing.requiredAsyncFn()).should.eventually.be.rejectedWith(`Cannot call requiredAsyncFn() - driver 'foo' is missing`));
+            // rejects in returned promise
+            return P.resolve().then(() => missing.requiredAsyncFn()).should.eventually.be.rejectedWith(`Cannot call requiredAsyncFn() - driver 'foo' is missing`);
+        });
+
+        it(`should provide a convenience function for the missing driver if it wants to throw the standard 'not implemented' error w/ standard message for the called fn`, () => {
+            drivers.missing = (id, notImplemented) => ({
+                id: 'my-missing-driver',
+                name: `Missing Driver: ${id}`,
+                optionalSyncFn () {
+                    throw notImplemented('optionalSyncFn');
+                }
+            });
+            const missing = drivers.get('foo');
+            missing.should.have.property('optionalSyncFn').that.is.a('function');
+            missing.optionalSyncFn.should.throw(`Cannot call optionalSyncFn() - driver 'foo' is missing`);
+        });
+
+        it(`should allow the missing driver to still supply an override for a joi-defaulted function that throws a different thown error`, () => {
+            drivers.missing = id => ({
+                name: `Missing Driver: ${id}`,
+                syncFn () {
+                    throw new Error(`My custom error`);
+                }
+            });
+            const missing = drivers.get('foo');
+            missing.should.have.property('syncFn').that.is.a('function');
+            missing.syncFn.should.throw(`My custom error`);
         });
 
         it(`should not allow a driver with id = 'missing' to be added when one has been configured on the manager`, () => {
@@ -105,7 +278,12 @@ describe('DriverManager', function () {
 
         it(`should not allow a default 'missing' driver to be set after a driver with the id 'missing' has been registered`, () => {
             const drivers = new DriverManager('things', schema, null);
-            drivers.add({ id: 'missing', name: 'Missing Driver' });
+            drivers.add({
+                id: 'missing',
+                name: 'Missing Driver',
+                requiredSyncFn: _.noop,
+                requiredAsyncFn: async () => ({})
+            });
             let error;
             try {
                 drivers.missing = () => ({ name: 'Missing Driver set late' });

--- a/test/module-spec.js
+++ b/test/module-spec.js
@@ -151,10 +151,6 @@ describe('DriverManager', function () {
             newDrivers.should.have.property('bar');
         });
 
-        it(`should return undefined if requesting a driver with an id argument but undefined value`, () => {
-            should.not.exist(drivers.get(undefined));
-        });
-
         it('should remove a driver', function () {
             drivers.remove('bar');
             drivers.keys().should.have.length(1);


### PR DESCRIPTION
- adds support for configuring a 'missing' default driver which is returned when attempting to 'get' an unknown driver before deciding whether to return null or throw
- converted DriverManager to a class
- converted from jshint to eslint
- updated dependencies

+feature