### PR TITLE
update lodash to version 4

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -64,7 +64,7 @@ class DriverManager extends EventEmitter {
             if (!(_type === 'object' && _flags.func && (_flags.default || _flags.presence === 'required'))) return acc;
 
             const makeError = notImplemented(_, child.key);
-            return _.set(acc, [child.key], (_.isAsyncFunction(_flags.default) || _.contains(_tags, 'async')) ? makeAsync(makeError) : makeSync(makeError));
+            return _.set(acc, [child.key], (_.isAsyncFunction(_flags.default) || _.includes(_tags, 'async')) ? makeAsync(makeError) : makeSync(makeError));
         }, {});
 
         this.drivers = {};

--- a/package.json
+++ b/package.json
@@ -36,6 +36,6 @@
   "dependencies": {
     "boom": "4.2.0",
     "joi": "~9.2.0",
-    "lodash": "~3.10.1"
+    "lodash": "^4.0.0"
   }
 }


### PR DESCRIPTION
Updates lodash to version 4.

A review of the code indicates that no other parts are affected by the breaking changes in the library update.